### PR TITLE
Add support for Fabric Minecraft

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.5.10"
     kotlin("plugin.serialization") version "1.5.20"
-    id("org.jetbrains.compose") version "0.5.0-build235"
+    id("org.jetbrains.compose") version "0.5.0-build245"
 }
 
 group = "com.redgrapefruit"

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/OpenLauncher.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/OpenLauncher.kt
@@ -119,7 +119,7 @@ class OpenLauncher private constructor(
         var command = "${findLocalJavaPath(optInLegacyJava)} $jvmArguments -classpath .;$root/versions/$version/$version-$jarTemplate.jar;${LibraryManager.getLibrariesFormatted(root, versionInfoObject)} $mainClass ${if (isServer) "nogui" else ""} $arguments"
 
         // Apply all tweaks
-        tweaks.forEach { tweak -> command = tweak.apply(command) }
+        tweaks.forEach { tweak -> command = tweak.apply(command, root, version, jarTemplate) }
 
         // Launch the Minecraft process
         try {

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/OpenLauncher.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/OpenLauncher.kt
@@ -1,6 +1,10 @@
 package com.redgrapefruit.openmodinstaller.launcher
 
 import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication
+import com.redgrapefruit.openmodinstaller.launcher.core.ArgumentManager
+import com.redgrapefruit.openmodinstaller.launcher.core.AuthManager
+import com.redgrapefruit.openmodinstaller.launcher.core.LibraryManager
+import com.redgrapefruit.openmodinstaller.launcher.core.SetupManager
 import com.sun.security.auth.module.NTSystem
 import kotlinx.serialization.json.*
 import java.io.*

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/ArgumentManager.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/ArgumentManager.kt
@@ -1,13 +1,10 @@
-package com.redgrapefruit.openmodinstaller.launcher
+package com.redgrapefruit.openmodinstaller.launcher.core
 
 import com.mcgoodtime.gjmlc.core.JavaArgumentHack
 import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication
 import com.redgrapefruit.openmodinstaller.data.ManifestReleaseType
 import com.redgrapefruit.openmodinstaller.util.plusAssign
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import org.apache.commons.lang3.SystemUtils
-import java.io.FileInputStream
 
 /**
  * Manages Minecraft process execution arguments

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/AuthManager.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/AuthManager.kt
@@ -1,8 +1,9 @@
-package com.redgrapefruit.openmodinstaller.launcher
+package com.redgrapefruit.openmodinstaller.launcher.core
 
 import com.mojang.authlib.Agent
 import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication
 import com.redgrapefruit.openmodinstaller.consts.AUTH_SERVICE
+import com.redgrapefruit.openmodinstaller.launcher.OpenLauncher
 import kotlinx.serialization.json.*
 import java.io.File
 import java.io.FileInputStream

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/LaunchCommandTweak.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/LaunchCommandTweak.kt
@@ -9,5 +9,5 @@ interface LaunchCommandTweak {
     /**
      * Tweaks the [source] command and returns the output result
      */
-    fun apply(source: String): String
+    fun apply(source: String, gamePath: String, targetVersion: String, jarTemplate: String): String
 }

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/LaunchCommandTweak.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/LaunchCommandTweak.kt
@@ -1,0 +1,13 @@
+package com.redgrapefruit.openmodinstaller.launcher.core
+
+/**
+ * A tweak to the launch command modifies the command, adds different options etc.
+ *
+ * An example of a [LaunchCommandTweak] would be using JARs for Fabric, Forge and Quilt since they're named differently.
+ */
+interface LaunchCommandTweak {
+    /**
+     * Tweaks the [source] command and returns the output result
+     */
+    fun apply(source: String): String
+}

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/LibraryManager.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/LibraryManager.kt
@@ -1,4 +1,4 @@
-package com.redgrapefruit.openmodinstaller.launcher
+package com.redgrapefruit.openmodinstaller.launcher.core
 
 import com.redgrapefruit.openmodinstaller.task.downloadFile
 import com.redgrapefruit.openmodinstaller.util.plusAssign
@@ -49,7 +49,7 @@ object LibraryManager {
     ) {
 
         // Save game path for later
-        this.gamePath = gamePath
+        LibraryManager.gamePath = gamePath
 
         // Check the main libraries array
         checkAndDownload(librariesArray, nativesPath)

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/SetupManager.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/core/SetupManager.kt
@@ -1,4 +1,4 @@
-package com.redgrapefruit.openmodinstaller.launcher
+package com.redgrapefruit.openmodinstaller.launcher.core
 
 import com.redgrapefruit.openmodinstaller.data.ManifestReleaseEntry
 import com.redgrapefruit.openmodinstaller.data.VersionManifest
@@ -9,7 +9,6 @@ import kotlinx.serialization.json.*
 import org.apache.commons.lang3.SystemUtils
 import java.io.File
 import java.io.FileInputStream
-import java.nio.file.Paths
 import kotlin.random.Random
 
 /**

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/fabric/FabricLaunchCommandTweak.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/fabric/FabricLaunchCommandTweak.kt
@@ -1,0 +1,14 @@
+package com.redgrapefruit.openmodinstaller.launcher.fabric
+
+import com.redgrapefruit.openmodinstaller.launcher.core.LaunchCommandTweak
+
+/**
+ * A [LaunchCommandTweak] that uses the Fabric JAR instead of the normal JAR
+ */
+object FabricLaunchCommandTweak : LaunchCommandTweak {
+    override fun apply(source: String, gamePath: String, targetVersion: String, jarTemplate: String): String {
+        return source.replace(
+            oldValue = "$gamePath/versions/$targetVersion/$targetVersion-$jarTemplate.jar",
+            newValue = "$gamePath/versions/$targetVersion-fabric/$targetVersion-fabric.jar")
+    }
+}

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/fabric/FabricManager.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/launcher/fabric/FabricManager.kt
@@ -1,0 +1,95 @@
+package com.redgrapefruit.openmodinstaller.launcher.fabric
+
+import com.redgrapefruit.openmodinstaller.task.downloadFile
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+object FabricManager {
+    /**
+     * The URL to the manifest with versions of the Fabric Installer
+     */
+    private const val INSTALLER_MANIFEST_URL = "https://meta.fabricmc.net/v2/versions/installer"
+
+    /**
+     * The URL to the FabricMC Maven hosting
+     */
+    private const val FABRIC_MAVEN_URL = "https://maven.fabricmc.net"
+
+    /**
+     * Downloads the JAR for Fabric Installer
+     */
+    fun setupFabricInstaller(
+        /**
+         * The root directory for Minecraft since FabricMC-related files are stored there, not in dedicated cache by design
+         */
+        gamePath: String) {
+
+        // Download the manifest first if it does not exist
+        val manifestDirectoryFile = File("$gamePath/system/manifests")
+        if (!manifestDirectoryFile.exists()) manifestDirectoryFile.mkdirs()
+
+        val manifestFile = File("$gamePath/system/manifests/installer_manifest")
+        if (!manifestFile.exists()) {
+            downloadFile(INSTALLER_MANIFEST_URL, manifestFile.absolutePath)
+        }
+
+        // Read the manifest
+        val manifestObject: JsonObject
+        FileInputStream(manifestFile).use { stream ->
+            manifestObject = Json.decodeFromString(JsonObject.serializer(), stream.readBytes().decodeToString())
+        }
+
+        // Get the latest manifest entry and obtain the version number
+        val latestObject = manifestObject[manifestObject.keys.first()]!!.jsonObject
+        val versionNumber = latestObject["version"]!!.jsonPrimitive.content
+
+        // Construct a link with the JAR from FabricMC Maven and download the JAR
+        val link = "$FABRIC_MAVEN_URL/net/fabricmc/fabric-installer/$versionNumber/fabric-installer-$versionNumber.jar"
+        downloadFile(link, "$gamePath/system/fabric/installer/installer_$versionNumber.jar")
+
+        // Also create a helper file that contains the installer version
+        val versionFile = File("$gamePath/system/fabric/util/installer_version.txt")
+        if (!versionFile.exists()) versionFile.createNewFile()
+        FileOutputStream(versionFile).use { stream ->
+            stream.write(versionNumber.encodeToByteArray())
+        }
+    }
+
+    /**
+     * Runs the Fabric Installer after its installation.
+     *
+     * If the installation hasn't occurred yet, it is run automatically by this function.
+     */
+    fun runFabricInstaller(
+        /**
+         * The root path for the game
+         */
+        gamePath: String,
+        /**
+         * The launched Minecraft version
+         */
+        targetVersion: String
+    ) {
+        // Get the helper file with the version
+        val versionFile = File("$gamePath/system/fabric/util/installer")
+        if (!versionFile.exists()) setupFabricInstaller(gamePath)
+        val versionNumber: String
+        FileInputStream(versionFile).use { stream ->
+            versionNumber = stream.readBytes().decodeToString()
+        }
+
+        // Get the installer file
+        val jarFile = File("$gamePath/system/fabric/installer/installer_$versionNumber.jar")
+        if (!jarFile.exists()) setupFabricInstaller(gamePath)
+
+        // Launch the installer file as in CLI
+        val command = "java -jar ${jarFile.absolutePath} client -dir $gamePath -mcversion $targetVersion -noprofile -snapshot"
+        val process = Runtime.getRuntime().exec(command) // Output observation like with the Minecraft process isn't enabled since it's rarely useful
+        process.waitFor()
+    }
+}

--- a/src/main/kotlin/com/redgrapefruit/openmodinstaller/main.kt
+++ b/src/main/kotlin/com/redgrapefruit/openmodinstaller/main.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import com.redgrapefruit.openmodinstaller.launcher.OpenLauncher
 import com.redgrapefruit.openmodinstaller.ui.Dashboard
 import com.redgrapefruit.openmodinstaller.ui.lightColors
 import kotlinx.serialization.json.Json
@@ -36,26 +37,29 @@ fun CWindow(title: String? = null, content: @Composable () -> Unit) = SwingUtili
 
     window.defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
 
-    // addind ComposePanel on JFrame
+    // adding ComposePanel on JFrame
     window.contentPane.add(composePanel, BorderLayout.CENTER)
 
     // setting the content
-    composePanel.setContent {
-        content()
-    }
+    composePanel.setContent { content() }
     window.minimumSize = Dimension(260, 100)
     window.setSize(800, 600)
-    window.setVisible(true)
+    window.isVisible = true
 }
 
 fun main() {
-    CWindow(title = "OpenModInstaller") {
-        MaterialTheme(colors = lightColors) {
-            DesktopTheme {
-                Surface(shape = RectangleShape, color = MaterialTheme.colors.background, modifier = Modifier.fillMaxSize()) {
-                    Dashboard()
-                }
-            }
-        }
-    }
+    val launcher = OpenLauncher.create("C:/Users/karpo/AppData/Roaming/.minecraft", testingLaunch = true)
+
+    launcher.setup("1.17.1", false)
+    launcher.launch(false, "Yass", 3000, "", "1.17.1", "release")
+
+//    CWindow(title = "OpenModInstaller") {
+//        MaterialTheme(colors = lightColors) {
+//            DesktopTheme {
+//                Surface(shape = RectangleShape, color = MaterialTheme.colors.background, modifier = Modifier.fillMaxSize()) {
+//                    Dashboard()
+//                }
+//            }
+//        }
+//    }
 }


### PR DESCRIPTION
Expand the launcher core's functionality to support the environments and mods created by the [Fabric Loader](https://github.com/FabricMC/fabric-loader).

This is a quite simple task, actually. Fabric has a [functional installer](https://github.com/FabricMC/fabric-installer) that does most of the heavy lifting for us.

The tasklist:

- [ ] Port over [ClientInstaller](https://github.com/FabricMC/fabric-installer/blob/master/src/main/java/net/fabricmc/installer/client/ClientInstaller.java) and other necessities for it if needed
- [ ] Add support for it in the launcher
- [ ] Make a few little tweaks to support launching the JAR